### PR TITLE
chore: fix typo (smg-automotive) in readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Usage
 ```
-npm install @smg-automotiv/next-page-bundlesize -D
+npm install @smg-automotive/next-page-bundlesize -D
 next build
 npx next-page-bundlesize --maxSize="150 kB" --buildDir=.next
 ```


### PR DESCRIPTION

## Motivation and context

Remove typo in readme file Usage part.

## Before
There was a typo @smg-automotiv in _npm install @smg-automotiv/next-page-bundlesize -D_

## After
Now it is _npm install @smg-automotive/next-page-bundlesize -D_

## How to test
Check README file (Usage) and try to run script in local _npm install @smg-automotiv/next-page-bundlesize -D_

