### PR TITLE
feat: include app router in bundle

### DIFF
--- a/src/__tests__/.next/app-build-manifest.json
+++ b/src/__tests__/.next/app-build-manifest.json
@@ -1,0 +1,10 @@
+{
+  "pages": {
+    "/[locale]/layout": [
+      "app-router-layout.js"
+    ],
+    "/[locale]/search": [
+      "app-router-search.js"
+    ]
+  }
+}

--- a/src/__tests__/.next/app-router-layout.js
+++ b/src/__tests__/.next/app-router-layout.js
@@ -1,0 +1,1 @@
+// layout.js

--- a/src/__tests__/.next/app-router-search.js
+++ b/src/__tests__/.next/app-router-search.js
@@ -1,0 +1,1 @@
+// app-router-search.js

--- a/src/__tests__/__snapshots__/check.test.ts.snap
+++ b/src/__tests__/__snapshots__/check.test.ts.snap
@@ -10,6 +10,14 @@ exports[`cli adds a delta to the new config if smaller than maxSize 1`] = `
     {
       "path": "src/__tests__/.next/.bundlesize__app",
       "maxSize": "5.03KB"
+    },
+    {
+      "path": "src/__tests__/.next/.bundlesize_-locale-_layout",
+      "maxSize": "5.03KB"
+    },
+    {
+      "path": "src/__tests__/.next/.bundlesize_-locale-_search",
+      "maxSize": "5.04KB"
     }
   ]
 }"
@@ -31,6 +39,14 @@ exports[`cli produces config with correct files and sizes 1`] = `
     {
       "path": "src/__tests__/.next/.bundlesize__app",
       "maxSize": "1 kB"
+    },
+    {
+      "path": "src/__tests__/.next/.bundlesize_-locale-_layout",
+      "maxSize": "1 kB"
+    },
+    {
+      "path": "src/__tests__/.next/.bundlesize_-locale-_search",
+      "maxSize": "1 kB"
     }
   ]
 }"
@@ -46,6 +62,14 @@ exports[`cli uses the previous config if defined 1`] = `
     {
       "path": "src/__tests__/.next/.bundlesize__app",
       "maxSize": "5.03KB"
+    },
+    {
+      "path": "src/__tests__/.next/.bundlesize_-locale-_layout",
+      "maxSize": "5.03KB"
+    },
+    {
+      "path": "src/__tests__/.next/.bundlesize_-locale-_search",
+      "maxSize": "5.04KB"
     }
   ]
 }"

--- a/src/check.ts
+++ b/src/check.ts
@@ -46,6 +46,7 @@ const concatenatePageBundles = ({
 }): string[] => {
   const pageBundles: string[] = [];
   manifests.forEach((manifest) => {
+    if (!manifest.pages) return;
     Object.keys(manifest.pages).forEach((page) => {
       const firstLoadChunks = combineAppAndPageChunks(manifest, page).map(
         (chunk) => path.join(buildDir, chunk),

--- a/src/check.ts
+++ b/src/check.ts
@@ -112,8 +112,8 @@ const loadFile = ({
   fileName: string;
 }) => {
   try {
-    const manifestAppRouterFile = path.join(buildDir, fileName);
-    return JSON.parse(fs.readFileSync(manifestAppRouterFile).toString());
+    const pathToLoad = path.join(buildDir, fileName);
+    return JSON.parse(fs.readFileSync(pathToLoad).toString());
   } catch (err) {
     const isFileNotExistingError =
       err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT';

--- a/src/check.ts
+++ b/src/check.ts
@@ -103,39 +103,39 @@ const extractArgs = (args: string[]) => {
   };
 };
 
+const loadFile = ({
+  buildDir,
+  fileName,
+}: {
+  buildDir: string;
+  fileName: string;
+}) => {
+  try {
+    const manifestAppRouterFile = path.join(buildDir, fileName);
+    return JSON.parse(fs.readFileSync(manifestAppRouterFile).toString());
+  } catch (err) {
+    const isFileNotExistingError =
+      err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT';
+
+    if (!isFileNotExistingError) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+      process.exit(1);
+    }
+  }
+};
+
 export default function check(args: string[]) {
   try {
     const { maxSize, buildDir, delta, previousConfigFileName } =
       extractArgs(args);
 
-    const manifestPagesRouterFile = path.join(buildDir, 'build-manifest.json');
-    const pagesManifest = JSON.parse(
-      fs.readFileSync(manifestPagesRouterFile).toString(),
-    );
-    const manifests = [pagesManifest];
-
-    try {
-      const manifestAppRouterFile = path.join(
-        buildDir,
-        'app-build-manifest.json',
-      );
-      const appManifest = JSON.parse(
-        fs.readFileSync(manifestAppRouterFile).toString(),
-      );
-      manifests.push(appManifest);
-    } catch (err) {
-      const isFileNotExistingError =
-        err &&
-        typeof err === 'object' &&
-        'code' in err &&
-        err.code === 'ENOENT';
-
-      if (!isFileNotExistingError) {
-        // eslint-disable-next-line no-console
-        console.log(err);
-        process.exit(1);
-      }
-    }
+    const manifests = [
+      // pages router build manifest
+      loadFile({ buildDir, fileName: 'build-manifest.json' }),
+      // app router build manifest
+      loadFile({ buildDir, fileName: 'app-build-manifest.json' }),
+    ];
 
     const pageBundles = concatenatePageBundles({
       buildDir,

--- a/src/check.ts
+++ b/src/check.ts
@@ -30,10 +30,12 @@ export interface BundleSizeConfig {
   }>;
 }
 
-const combineAppAndPageChunks = (manifest: Manifest, page: string) =>
-  Array.from(
-    new Set([...manifest.pages['/_app'], ...manifest.pages[page]]),
+const combineAppAndPageChunks = (manifest: Manifest, page: string) => {
+  const appPageChunks = manifest.pages['/_app'];
+  return Array.from(
+    new Set([...(appPageChunks ? appPageChunks : []), ...manifest.pages[page]]),
   ).filter((chunk) => chunk.match(/\.js$/));
+};
 
 const concatenatePageBundles = ({
   buildDir,

--- a/src/check.ts
+++ b/src/check.ts
@@ -46,7 +46,6 @@ const concatenatePageBundles = ({
 }): string[] => {
   const pageBundles: string[] = [];
   manifests.forEach((manifest) => {
-    if (!manifest.pages) return;
     Object.keys(manifest.pages).forEach((page) => {
       const firstLoadChunks = combineAppAndPageChunks(manifest, page).map(
         (chunk) => path.join(buildDir, chunk),
@@ -110,7 +109,7 @@ const loadFile = ({
 }: {
   buildDir: string;
   fileName: string;
-}) => {
+}): Manifest => {
   try {
     const pathToLoad = path.join(buildDir, fileName);
     return JSON.parse(fs.readFileSync(pathToLoad).toString());
@@ -123,6 +122,7 @@ const loadFile = ({
       console.log(err);
       process.exit(1);
     }
+    return { pages: {} };
   }
 };
 


### PR DESCRIPTION
References https://smg-au.atlassian.net/browse/DM-3641

## Motivation and context

App router pages create a separate manifest file. This extends the check to include both, app router and pages router files.

## How to test

- [hci-web](https://app.circleci.com/pipelines/github/smg-automotive/hci-web/342/workflows/12ab8d3b-43d4-440c-977e-23eb050d482a/jobs/2366) -> app router only
- [seller-web](https://app.circleci.com/pipelines/github/smg-automotive/seller-web/13828/workflows/f076249a-64d0-4d08-95e1-84aa4cba6958/jobs/96308) -> pages AND app router mixed
- [listings-web](https://app.circleci.com/pipelines/github/smg-automotive/listings-web/14723/workflows/ec27b62b-af0c-46e9-926a-e66ab4b3656b/jobs/105028) -> pages router only