### PR TITLE
chore: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/" # location of package.json
+    schedule:
+      interval: "daily"
+    reviewers:
+      - "smg-automotive/frontend"


### PR DESCRIPTION
References [VSST-2918](https://smg-au.atlassian.net/browse/VSST-2918)

## Motivation and context

Adds dependabot configuration which differs from default config in two ways:

1. automatically assigns `smg-automotive/frontend` as reviewer (goal of the ticket)
2. checks for updates every work day instead of once weekly (default config)

More info about `dependabot.yml` can be found [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)

## Before

No dependabot config.

## After

Dependabot config exists.

## How to test

- ensure PRs opened by dependabot automatically assign FE team as reviewer (this can only be verified after the PR is merged to main)

[VSST-2918]: https://smg-au.atlassian.net/browse/VSST-2918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ