### PR TITLE
feat(manifest): include manifest for next version 16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ dist/
 *.tsbuildinfo
 .npm
 .eslintcache
-src/__tests__/.next/next-page-bundlesize.config.json
-src/__tests__/.next/.bundlesize*
-src/__tests__/.next/new-master-config.json
-src/__tests__/.next/bundlesize.json
+src/__tests__/.next*/next-page-bundlesize.config.json
+src/__tests__/.next*/.bundlesize*
+src/__tests__/.next*/new-master-config.json
+src/__tests__/.next*/bundlesize.json

--- a/src/__tests__/.next-next16/app-path-routes-manifest.json
+++ b/src/__tests__/.next-next16/app-path-routes-manifest.json
@@ -1,0 +1,6 @@
+{
+  "/_not-found/page": "/_not-found",
+  "/[locale]/page": "/[locale]",
+  "/[locale]/product/page": "/[locale]/product",
+  "/api/ready/route": "/api/ready"
+}

--- a/src/__tests__/.next-next16/build-manifest.json
+++ b/src/__tests__/.next-next16/build-manifest.json
@@ -1,0 +1,3 @@
+{
+  "rootMainFiles": ["framework.js", "main-app.js"]
+}

--- a/src/__tests__/.next-next16/encoded-home-page.js
+++ b/src/__tests__/.next-next16/encoded-home-page.js
@@ -1,0 +1,1 @@
+// encoded-home-page.js

--- a/src/__tests__/.next-next16/framework.js
+++ b/src/__tests__/.next-next16/framework.js
@@ -1,0 +1,1 @@
+// framework.js

--- a/src/__tests__/.next-next16/main-app.js
+++ b/src/__tests__/.next-next16/main-app.js
@@ -1,0 +1,1 @@
+// main-app.js

--- a/src/__tests__/.next-next16/not-found.js
+++ b/src/__tests__/.next-next16/not-found.js
@@ -1,0 +1,1 @@
+// not-found.js

--- a/src/__tests__/.next-next16/product-page.js
+++ b/src/__tests__/.next-next16/product-page.js
@@ -1,0 +1,1 @@
+// product-page.js

--- a/src/__tests__/.next-next16/server/app-paths-manifest.json
+++ b/src/__tests__/.next-next16/server/app-paths-manifest.json
@@ -1,0 +1,6 @@
+{
+  "/_not-found/page": "app/_not-found/page.js",
+  "/[locale]/page": "app/[locale]/page.js",
+  "/[locale]/product/page": "app/[locale]/product/page.js",
+  "/api/ready/route": "app/api/ready/route.js"
+}

--- a/src/__tests__/.next-next16/server/app/[locale]/page_client-reference-manifest.js
+++ b/src/__tests__/.next-next16/server/app/[locale]/page_client-reference-manifest.js
@@ -2,7 +2,10 @@ globalThis.__RSC_MANIFEST = {
   page: {
     clientModules: {
       home: {
-        chunks: ["shared-layout.js", "encoded-home-page.js"],
+        chunks: [
+          '/_next/static/chunks/shared-layout.js',
+          '/_next/static/chunks/encoded-home-page.js',
+        ],
       },
     },
   },

--- a/src/__tests__/.next-next16/server/app/[locale]/page_client-reference-manifest.js
+++ b/src/__tests__/.next-next16/server/app/[locale]/page_client-reference-manifest.js
@@ -1,0 +1,9 @@
+globalThis.__RSC_MANIFEST = {
+  page: {
+    clientModules: {
+      home: {
+        chunks: ["shared-layout.js", "encoded-home-page.js"],
+      },
+    },
+  },
+};

--- a/src/__tests__/.next-next16/server/app/[locale]/product/page_client-reference-manifest.js
+++ b/src/__tests__/.next-next16/server/app/[locale]/product/page_client-reference-manifest.js
@@ -2,7 +2,10 @@ globalThis.__RSC_MANIFEST = {
   page: {
     clientModules: {
       product: {
-        chunks: ["shared-layout.js", "product-page.js"],
+        chunks: [
+          '/_next/static/chunks/shared-layout.js',
+          '/_next/static/chunks/product-page.js',
+        ],
       },
     },
   },

--- a/src/__tests__/.next-next16/server/app/[locale]/product/page_client-reference-manifest.js
+++ b/src/__tests__/.next-next16/server/app/[locale]/product/page_client-reference-manifest.js
@@ -1,0 +1,9 @@
+globalThis.__RSC_MANIFEST = {
+  page: {
+    clientModules: {
+      product: {
+        chunks: ["shared-layout.js", "product-page.js"],
+      },
+    },
+  },
+};

--- a/src/__tests__/.next-next16/server/app/_not-found/page_client-reference-manifest.js
+++ b/src/__tests__/.next-next16/server/app/_not-found/page_client-reference-manifest.js
@@ -1,0 +1,9 @@
+globalThis.__RSC_MANIFEST = {
+  page: {
+    clientModules: {
+      "not-found": {
+        chunks: ["shared-layout.js", "not-found.js"],
+      },
+    },
+  },
+};

--- a/src/__tests__/.next-next16/server/app/_not-found/page_client-reference-manifest.js
+++ b/src/__tests__/.next-next16/server/app/_not-found/page_client-reference-manifest.js
@@ -1,8 +1,11 @@
 globalThis.__RSC_MANIFEST = {
   page: {
     clientModules: {
-      "not-found": {
-        chunks: ["shared-layout.js", "not-found.js"],
+      'not-found': {
+        chunks: [
+          '/_next/static/chunks/shared-layout.js',
+          '/_next/static/chunks/not-found.js',
+        ],
       },
     },
   },

--- a/src/__tests__/.next-next16/shared-layout.js
+++ b/src/__tests__/.next-next16/shared-layout.js
@@ -1,0 +1,1 @@
+// shared-layout.js

--- a/src/__tests__/.next-next16/static/chunks/encoded-home-page.js
+++ b/src/__tests__/.next-next16/static/chunks/encoded-home-page.js
@@ -1,0 +1,1 @@
+// encoded-home-page.js

--- a/src/__tests__/.next-next16/static/chunks/not-found.js
+++ b/src/__tests__/.next-next16/static/chunks/not-found.js
@@ -1,0 +1,1 @@
+// not-found.js

--- a/src/__tests__/.next-next16/static/chunks/product-page.js
+++ b/src/__tests__/.next-next16/static/chunks/product-page.js
@@ -1,0 +1,1 @@
+// product-page.js

--- a/src/__tests__/.next-next16/static/chunks/shared-layout.js
+++ b/src/__tests__/.next-next16/static/chunks/shared-layout.js
@@ -1,0 +1,1 @@
+// shared-layout.js

--- a/src/__tests__/__snapshots__/check.test.ts.snap
+++ b/src/__tests__/__snapshots__/check.test.ts.snap
@@ -52,6 +52,33 @@ exports[`cli produces config with correct files and sizes 1`] = `
 }"
 `;
 
+exports[`cli produces route-specific bundles for next 16 app routes 1`] = `
+"{
+  "files": [
+    {
+      "path": "src/__tests__/.next-next16/.bundlesize__not-found",
+      "maxSize": "1 kB"
+    },
+    {
+      "path": "src/__tests__/.next-next16/.bundlesize_-locale-",
+      "maxSize": "1 kB"
+    },
+    {
+      "path": "src/__tests__/.next-next16/.bundlesize_-locale-_product",
+      "maxSize": "1 kB"
+    }
+  ]
+}"
+`;
+
+exports[`cli produces route-specific bundles for next 16 app routes 2`] = `
+"// framework.js
+// main-app.js
+// shared-layout.js
+// encoded-home-page.js
+"
+`;
+
 exports[`cli uses the previous config if defined 1`] = `
 "{
   "files": [

--- a/src/__tests__/check.test.ts
+++ b/src/__tests__/check.test.ts
@@ -8,7 +8,6 @@ const validRunConfig = [
   '--maxSize',
   '1 kB',
   '--buildDir',
-  './src/__tests__/.next',
 ];
 
 describe('cli', () => {
@@ -20,7 +19,7 @@ describe('cli', () => {
   });
 
   it('produces config with correct files and sizes', () => {
-    check(validRunConfig);
+    check(validRunConfig.concat('./src/__tests__/.next'));
 
     const config = fs
       .readFileSync('./src/__tests__/.next/next-page-bundlesize.config.json')
@@ -30,7 +29,7 @@ describe('cli', () => {
   });
 
   it('produces concatenated bundle file', () => {
-    check(validRunConfig);
+    check(validRunConfig.concat('./src/__tests__/.next'));
 
     const page = fs
       .readFileSync('./src/__tests__/.next/.bundlesize_')
@@ -53,7 +52,7 @@ describe('cli', () => {
 
   it('uses the previous config if defined', () => {
     check([
-      ...validRunConfig,
+      ...validRunConfig.concat('./src/__tests__/.next'),
       '--previousConfigFileName',
       'master-config.json',
     ]);
@@ -66,7 +65,7 @@ describe('cli', () => {
 
   it('adds a delta to the new config if smaller than maxSize', () => {
     check([
-      ...validRunConfig,
+      ...validRunConfig.concat('./src/__tests__/.next'),
       '--previousConfigFileName',
       'master-config.json',
       '--delta',
@@ -77,5 +76,26 @@ describe('cli', () => {
       .readFileSync('./src/__tests__/.next/bundlesize.json')
       .toString();
     expect(updatedConfig).toMatchSnapshot();
+  });
+
+  it('produces route-specific bundles for next 16 app routes', () => {
+    check(validRunConfig.concat('./src/__tests__/.next-next16'));
+
+    const config = fs
+      .readFileSync(
+        './src/__tests__/.next-next16/next-page-bundlesize.config.json',
+      )
+      .toString();
+    expect(config).toMatchSnapshot();
+
+    const homePageBundle = fs
+      .readFileSync('./src/__tests__/.next-next16/.bundlesize_-locale-')
+      .toString();
+    expect(homePageBundle).toMatchSnapshot();
+
+    expect(
+      fs.existsSync('./src/__tests__/.next-next16/.bundlesize__api_ready'),
+    ).toBe(false);
+    expect(mockExit).toHaveBeenCalledWith(0);
   });
 });

--- a/src/check.ts
+++ b/src/check.ts
@@ -137,6 +137,8 @@ export default function check(args: string[]) {
       loadFile({ buildDir, fileName: 'build-manifest.json' }),
       // app router build manifest
       loadFile({ buildDir, fileName: 'app-build-manifest.json' }),
+      // next version 16
+      loadFile({ buildDir, fileName: 'app-path-routes-manifest.json' }),
     ];
 
     const pageBundles = concatenatePageBundles({

--- a/src/check.ts
+++ b/src/check.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
+import vm from 'vm';
 import path from 'path';
 import fs from 'fs';
 import { execSync } from 'child_process';
@@ -17,11 +18,226 @@ interface Args {
 }
 
 interface Manifest {
-  pages: {
+  pages?: {
     [pageName: string]: string[];
   };
-  [key: string]: Record<string, string | string[]>;
+  rootMainFiles?: string[];
 }
+
+interface AppPathRoutesManifest {
+  [routeName: string]: string;
+}
+
+interface AppPathsManifest {
+  [routeName: string]: string;
+}
+
+interface ClientModule {
+  chunks?: string[];
+}
+
+interface ClientReferenceManifest {
+  clientModules?: Record<string, ClientModule>;
+}
+
+type PageChunkMap = Map<string, string[]>;
+
+const isFileNotExistingError = (err: unknown): err is NodeJS.ErrnoException =>
+  Boolean(
+    err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT',
+  );
+
+const isJavaScriptChunk = (chunk: string) => chunk.endsWith('.js');
+
+const uniqueJavaScriptChunks = (chunks: string[]) =>
+  Array.from(new Set(chunks.filter(isJavaScriptChunk)));
+
+const addPageChunks = (
+  pageChunks: PageChunkMap,
+  page: string,
+  chunks: string[],
+) => {
+  const uniqueChunks = uniqueJavaScriptChunks(chunks);
+  if (!uniqueChunks.length) {
+    return;
+  }
+
+  pageChunks.set(
+    page,
+    Array.from(new Set([...(pageChunks.get(page) || []), ...uniqueChunks])),
+  );
+};
+
+const toBundleFileName = (page: string) =>
+  `.bundlesize${page.replace(/\//g, '_').replace(/\[/g, '-').replace(/\]/g, '-')}`;
+
+const clientReferenceManifestPathFromServerPage = (serverPagePath: string) =>
+  serverPagePath
+    .replace(/^app\//, 'server/app/')
+    .replace(/\.js$/, '_client-reference-manifest.js');
+
+const collectClientReferenceChunks = (
+  clientReferenceManifest: ClientReferenceManifest,
+) =>
+  uniqueJavaScriptChunks(
+    Object.values(clientReferenceManifest.clientModules || {}).flatMap(
+      ({ chunks = [] }) => chunks,
+    ),
+  );
+
+const chunkFilePath = (buildDir: string, chunk: string) => {
+  try {
+    return path.join(buildDir, decodeURIComponent(chunk));
+  } catch {
+    return path.join(buildDir, chunk);
+  }
+};
+
+const collectLegacyManifestChunks = (manifest: Manifest) => {
+  const pageChunks: PageChunkMap = new Map();
+
+  Object.keys(manifest.pages || {}).forEach((page) => {
+    addPageChunks(pageChunks, page, combineAppAndPageChunks(manifest, page));
+  });
+
+  return pageChunks;
+};
+
+const mergePageChunks = (
+  targetPageChunks: PageChunkMap,
+  pageChunksToMerge: PageChunkMap,
+) => {
+  pageChunksToMerge.forEach((chunks, page) => {
+    addPageChunks(targetPageChunks, page, chunks);
+  });
+};
+
+const loadJsonFile = <T>({
+  buildDir,
+  fileName,
+  fallback,
+}: {
+  buildDir: string;
+  fileName: string;
+  fallback: T;
+}): T => {
+  try {
+    const pathToLoad = path.join(buildDir, fileName);
+    return JSON.parse(fs.readFileSync(pathToLoad).toString()) as T;
+  } catch (err) {
+    if (!isFileNotExistingError(err)) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+      process.exit(1);
+    }
+
+    return fallback;
+  }
+};
+
+const loadClientReferenceManifest = ({
+  buildDir,
+  fileName,
+}: {
+  buildDir: string;
+  fileName: string;
+}): ClientReferenceManifest => {
+  try {
+    const pathToLoad = path.join(buildDir, fileName);
+    const fileContents = fs.readFileSync(pathToLoad).toString();
+    const sandbox: {
+      globalThis: {
+        __RSC_MANIFEST?: Record<string, ClientReferenceManifest>;
+      };
+    } = { globalThis: {} };
+
+    vm.runInNewContext(fileContents, sandbox, { timeout: 1000 });
+
+    return Object.values(sandbox.globalThis.__RSC_MANIFEST || {})[0] || {};
+  } catch (err) {
+    if (!isFileNotExistingError(err)) {
+      // eslint-disable-next-line no-console
+      console.log(err);
+      process.exit(1);
+    }
+
+    return {};
+  }
+};
+
+const collectNext16AppRouteChunks = (buildDir: string) => {
+  const buildManifest = loadJsonFile<Manifest>({
+    buildDir,
+    fileName: 'build-manifest.json',
+    fallback: {},
+  });
+  const appPathRoutesManifest = loadJsonFile<AppPathRoutesManifest>({
+    buildDir,
+    fileName: 'app-path-routes-manifest.json',
+    fallback: {},
+  });
+  const appPathsManifest = loadJsonFile<AppPathsManifest>({
+    buildDir,
+    fileName: path.join('server', 'app-paths-manifest.json'),
+    fallback: {},
+  });
+  const pageChunks: PageChunkMap = new Map();
+  const sharedAppChunks = uniqueJavaScriptChunks(
+    buildManifest.rootMainFiles || [],
+  );
+
+  Object.entries(appPathRoutesManifest).forEach(([routeName, publicRoute]) => {
+    if (!routeName.endsWith('/page')) {
+      return;
+    }
+
+    const serverPagePath = appPathsManifest[routeName];
+
+    if (!serverPagePath) {
+      return;
+    }
+
+    const clientReferenceManifest = loadClientReferenceManifest({
+      buildDir,
+      fileName: clientReferenceManifestPathFromServerPage(serverPagePath),
+    });
+
+    addPageChunks(pageChunks, publicRoute, [
+      ...sharedAppChunks,
+      ...collectClientReferenceChunks(clientReferenceManifest),
+    ]);
+  });
+
+  return pageChunks;
+};
+
+const collectAllPageChunks = (buildDir: string) => {
+  const pageChunks: PageChunkMap = new Map();
+
+  mergePageChunks(
+    pageChunks,
+    collectLegacyManifestChunks(
+      loadJsonFile<Manifest>({
+        buildDir,
+        fileName: 'build-manifest.json',
+        fallback: {},
+      }),
+    ),
+  );
+  mergePageChunks(
+    pageChunks,
+    collectLegacyManifestChunks(
+      loadJsonFile<Manifest>({
+        buildDir,
+        fileName: 'app-build-manifest.json',
+        fallback: {},
+      }),
+    ),
+  );
+  mergePageChunks(pageChunks, collectNext16AppRouteChunks(buildDir));
+
+  return pageChunks;
+};
 
 export interface BundleSizeConfig {
   files: Array<{
@@ -31,40 +247,37 @@ export interface BundleSizeConfig {
 }
 
 const combineAppAndPageChunks = (manifest: Manifest, page: string) => {
-  const appPageChunks = manifest.pages['/_app'];
+  const appPageChunks = manifest.pages?.['/_app'];
   return Array.from(
-    new Set([...(appPageChunks ? appPageChunks : []), ...manifest.pages[page]]),
+    new Set([
+      ...(appPageChunks ? appPageChunks : []),
+      ...(manifest.pages?.[page] || []),
+    ]),
   ).filter((chunk) => chunk.match(/\.js$/));
 };
 
 const concatenatePageBundles = ({
   buildDir,
-  manifests,
+  pageChunks,
 }: {
   buildDir: string;
-  manifests: Manifest[];
+  pageChunks: PageChunkMap;
 }): string[] => {
   const pageBundles: string[] = [];
-  manifests.forEach((manifest) => {
-    Object.keys(manifest.pages).forEach((page) => {
-      const firstLoadChunks = combineAppAndPageChunks(manifest, page).map(
-        (chunk) => path.join(buildDir, chunk),
-      );
 
-      const outFile = path.join(
-        buildDir,
-        // eslint-disable-next-line sonarjs/single-char-in-character-classes
-        `.bundlesize${page.replace(/[/]/g, '_').replace(/[[\]]/g, '-')}`,
-      );
+  pageChunks.forEach((chunks, page) => {
+    const firstLoadChunks = chunks.map((chunk) =>
+      chunkFilePath(buildDir, chunk),
+    );
+    const outFile = path.join(buildDir, toBundleFileName(page));
 
-      fs.writeFileSync(outFile, '');
-      firstLoadChunks.forEach((chunk) => {
-        const chunkContent = fs.readFileSync(chunk);
-        fs.appendFileSync(outFile, chunkContent);
-      });
-
-      pageBundles.push(outFile);
+    fs.writeFileSync(outFile, '');
+    firstLoadChunks.forEach((chunk) => {
+      const chunkContent = fs.readFileSync(chunk);
+      fs.appendFileSync(outFile, chunkContent);
     });
+
+    pageBundles.push(outFile);
   });
 
   return pageBundles;
@@ -104,46 +317,14 @@ const extractArgs = (args: string[]) => {
   };
 };
 
-const loadFile = ({
-  buildDir,
-  fileName,
-}: {
-  buildDir: string;
-  fileName: string;
-}): Manifest => {
-  try {
-    const pathToLoad = path.join(buildDir, fileName);
-    return JSON.parse(fs.readFileSync(pathToLoad).toString());
-  } catch (err) {
-    const isFileNotExistingError =
-      err && typeof err === 'object' && 'code' in err && err.code === 'ENOENT';
-
-    if (!isFileNotExistingError) {
-      // eslint-disable-next-line no-console
-      console.log(err);
-      process.exit(1);
-    }
-    return { pages: {} };
-  }
-};
-
 export default function check(args: string[]) {
   try {
     const { maxSize, buildDir, delta, previousConfigFileName } =
       extractArgs(args);
 
-    const manifests = [
-      // pages router build manifest
-      loadFile({ buildDir, fileName: 'build-manifest.json' }),
-      // app router build manifest
-      loadFile({ buildDir, fileName: 'app-build-manifest.json' }),
-      // next version 16
-      loadFile({ buildDir, fileName: 'app-path-routes-manifest.json' }),
-    ];
-
     const pageBundles = concatenatePageBundles({
       buildDir,
-      manifests,
+      pageChunks: collectAllPageChunks(buildDir),
     });
     const previousConfiguration = getPreviousConfig(
       buildDir,

--- a/src/check.ts
+++ b/src/check.ts
@@ -85,11 +85,13 @@ const collectClientReferenceChunks = (
     ),
   );
 
+const normalizeChunkPath = (chunk: string) => chunk.replace(/^\/?_next\//, '');
+
 const chunkFilePath = (buildDir: string, chunk: string) => {
   try {
-    return path.join(buildDir, decodeURIComponent(chunk));
+    return path.join(buildDir, decodeURIComponent(normalizeChunkPath(chunk)));
   } catch {
-    return path.join(buildDir, chunk);
+    return path.join(buildDir, normalizeChunkPath(chunk));
   }
 };
 


### PR DESCRIPTION
## Motivation and Context

- See: https://github.com/smg-automotive/au-fe-docs/discussions/129#discussioncomment-16652547

## After

- Support build manifest in NextJS version 16

## How to test

- Verified to work both on `next-example` (NextJS version 16.1.7) and `seller-web` (NextJS version 15.5.15)
