### PR TITLE
chore: prepare for monorepo migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,23 +126,3 @@ workflows:
           <<: *SLACK_NOTIFICATION_CONTEXT
           requires:
             - install
-      - pre_release:
-          <<: *NPM_PUBLISHING_CONTEXT
-          requires:
-            - lint
-            - unit
-            - typecheck
-            - build
-          filters:
-            branches:
-              ignore: main
-      - release:
-          <<: *NPM_PUBLISHING_CONTEXT
-          requires:
-            - lint
-            - unit
-            - typecheck
-            - build
-          filters:
-            branches:
-              only: main

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 
 # next-page-bundlesize-pkg
+
+> [!IMPORTANT]
+> This project is being migrated into [smg-automotive/automotive-web](https://github.com/smg-automotive/automotive-web/). Please check the monorepo before starting new work in this repository.
+
 ## Page-level bundle size check for next.js
 
 


### PR DESCRIPTION
References [FED-1216](https://smg-au.atlassian.net/browse/FED-1216)

## Motivation and context

We'll be migrating this package to monorepo. This PR adds a migration banner, and disables the release jobs to prepare the package for ingestion.

[FED-1216]: https://smg-au.atlassian.net/browse/FED-1216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ